### PR TITLE
Add domain intelligence lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DISCORD_TOKEN=your-discord-token
+DISCORD_CHANNEL=your-channel-id
+PIHOLE_URL=http://localhost/admin/api.php
+ADGUARD_URL=
+MODEL_PATH=./tinyllama-model
+REPORT_TIME=09:00
+DOMAIN_INFO_API=https://api.domainsdb.info/v1/domains/search?domain=

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,24 @@
+# Project Plan for AdSnitch
+
+This document tracks tasks derived from the README goals.
+
+## Phase 1 - Core Bot
+
+- [ ] Initialize Node.js project
+- [ ] Create environment variable template
+- [ ] Build Discord bot skeleton
+- [ ] Implement log parsing for Pi-hole/AdGuard
+- [ ] Aggregate daily DNS request statistics
+- [ ] Generate satirical summary using TinyLlama (stub)
+- [ ] Fetch domain info for context-aware summary
+- [ ] Schedule daily summary via cron
+- [ ] Send summary to Discord as an embed
+
+## Phase 2 - Extended Features
+
+- [ ] Web UI for configuring tone presets
+- [ ] Support other DNS filters (NextDNS, Unbound)
+- [ ] Add meme mode
+- [ ] Add Munna Bhai mode
+
+Future improvements may include tests, packaging, and more robust summarization.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Because... why not?
 - **Discord bot** integration with clean embeds
 - Supports **Pi-hole** and **AdGuard Home** as data sources
 - Fully customizable tone: sarcastic, serious, sysadmin-rage, or Munna Bhai-style
+- **Domain intelligence** lookup for context-aware summaries
 
 ## Screenshots
 
@@ -36,8 +37,9 @@ Because... why not?
 
 1. Parse DNS logs from Pi-hole / AdGuard Home (via API or log scrape).
 2. Aggregate daily request data (blocked domains, counts, time trends).
-3. Use TinyLlama to generate a satirical summary.
-4. Send report as a Discord embed to your channel.
+3. Look up domain details via API.
+4. Use TinyLlama to generate a satirical summary.
+5. Send report as a Discord embed to your channel.
 
 ## Installation
 
@@ -58,6 +60,7 @@ npm run start
 | `ADGUARD_URL`   | (Optional) AdGuard Home API base URL         |
 | `MODEL_PATH`    | Path to TinyLlama model for local inference  |
 | `REPORT_TIME`   | Time of day to send daily summaries (HH\:MM) |
+| `DOMAIN_INFO_API` | API endpoint for domain lookups |
 
 ## TODOs
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,74 @@
+require('dotenv').config();
+const { Client, GatewayIntentBits, EmbedBuilder } = require('discord.js');
+const cron = require('node-cron');
+const fetch = require('node-fetch');
+
+const token = process.env.DISCORD_TOKEN;
+const channelId = process.env.DISCORD_CHANNEL;
+const reportTime = process.env.REPORT_TIME || '09:00';
+const domainInfoApi = process.env.DOMAIN_INFO_API || 'https://api.domainsdb.info/v1/domains/search?domain=';
+
+// Placeholder: fetch and aggregate DNS log stats
+async function getDailyStats() {
+  return {
+    topDomains: ['example.com'],
+    suspiciousPatterns: ['weird.example'],
+    weirdDomains: ['strange.domain']
+  };
+}
+
+// Retrieve extra information about a domain
+async function getDomainInfo(domain) {
+  try {
+    const res = await fetch(`${domainInfoApi}${domain}`);
+    return await res.json();
+  } catch (err) {
+    console.error('Domain info lookup failed:', err);
+    return null;
+  }
+}
+
+// Placeholder: use TinyLlama or other model to generate satirical text
+async function generateSummary(stats) {
+  // Fetch info for each top domain
+  const infos = await Promise.all(
+    stats.topDomains.map((d) => getDomainInfo(d))
+  );
+
+  // In a real implementation, pass stats and infos to TinyLlama
+  let lines = [`Top domain: ${stats.topDomains[0]}`];
+  infos.forEach((info, idx) => {
+    if (info && info.domains && info.domains[0]) {
+      const d = info.domains[0];
+      lines.push(
+        `${d.domain} (created ${d.create_date || 'unknown'})`
+      );
+    }
+  });
+
+  return lines.join('\n');
+}
+
+async function sendReport(client) {
+  const stats = await getDailyStats();
+  const summary = await generateSummary(stats);
+
+  const embed = new EmbedBuilder()
+    .setTitle('AdSnitch Daily Report')
+    .setDescription(summary)
+    .setColor(0xff9900);
+
+  const channel = await client.channels.fetch(channelId);
+  if (channel) await channel.send({ embeds: [embed] });
+}
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+client.once('ready', () => {
+  console.log('AdSnitch bot ready');
+  const [hour, minute] = reportTime.split(':');
+  cron.schedule(`${minute} ${hour} * * *`, () => sendReport(client), {
+    timezone: 'UTC'
+  });
+});
+
+client.login(token);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "adsnitch",
+  "version": "1.0.0",
+  "description": "_Your TinyLlama-powered Discord tattletale that exposes the shady world of DNS requests — with sarcasm._",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.0.0",
+    "dotenv": "^16.0.0",
+    "node-cron": "^3.0.0",
+    "node-fetch": "^2.6.7"
+  }
+}


### PR DESCRIPTION
## Summary
- fetch domain info for top blocked domains
- generate richer summaries using domain metadata
- document DOMAIN_INFO_API configuration
- include node-fetch dependency
- update project plan for new feature

## Testing
- `node -v`
- `npm --version`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ffad08d9c8330869e08b408b63817