### PR TITLE
Add TinyLlama summarizer and RDAP lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DISCORD_TOKEN=your-discord-token
+DISCORD_CHANNEL=your-channel-id
+PIHOLE_URL=http://localhost/admin/api.php
+ADGUARD_URL=
+MODEL_PATH=./tinyllama-model
+REPORT_TIME=09:00
+# Optional custom API, otherwise RDAP.org will be used
+DOMAIN_INFO_API=

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,25 @@
+# Project Plan for AdSnitch
+
+This document tracks tasks derived from the README goals.
+
+## Phase 1 - Core Bot
+
+- [x] Initialize Node.js project
+- [x] Create environment variable template
+- [x] Build Discord bot skeleton
+- [ ] Implement log parsing for Pi-hole/AdGuard
+- [ ] Aggregate daily DNS request statistics
+- [x] Provide mock log plugin and domain owner DB
+- [x] Generate satirical summary using TinyLlama
+- [x] Fetch domain info for context-aware summary
+- [x] Schedule daily summary via cron
+- [x] Send summary to Discord as an embed
+
+## Phase 2 - Extended Features
+
+- [ ] Web UI for configuring tone presets
+- [ ] Support other DNS filters (NextDNS, Unbound)
+- [ ] Add meme mode
+- [ ] Add Munna Bhai mode
+
+Future improvements may include tests, packaging, and more robust summarization.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Because... why not?
 ## Features
 
 - **Daily summaries** of DNS blocklists
-- **Powered by TinyLlama** for intelligent (and satirical) report generation
+- **Powered by TinyLlama** via `node-llama-cpp` for intelligent (and satirical) report generation
 - **Discord bot** integration with clean embeds
 - Supports **Pi-hole** and **AdGuard Home** as data sources
 - Fully customizable tone: sarcastic, serious, sysadmin-rage, or Munna Bhai-style
+- **Domain intelligence** lookup via RDAP for context-aware summaries
 
 ## Screenshots
 
@@ -36,8 +37,11 @@ Because... why not?
 
 1. Parse DNS logs from Pi-hole / AdGuard Home (via API or log scrape).
 2. Aggregate daily request data (blocked domains, counts, time trends).
-3. Use TinyLlama to generate a satirical summary.
-4. Send report as a Discord embed to your channel.
+3. Look up domain details via RDAP (or your custom API) and local `domains.db`.
+4. Use TinyLlama (through `node-llama-cpp`) to craft a satirical summary.
+5. Send report as a Discord embed to your channel.
+
+For development, a `mock_logs.json` file mimics Pi-hole/AdGuard output. A simple plugin reads this data so you can test without a real DNS filter.
 
 ## Installation
 
@@ -58,6 +62,12 @@ npm run start
 | `ADGUARD_URL`   | (Optional) AdGuard Home API base URL         |
 | `MODEL_PATH`    | Path to TinyLlama model for local inference  |
 | `REPORT_TIME`   | Time of day to send daily summaries (HH\:MM) |
+| `DOMAIN_INFO_API` | Optional API endpoint for domain lookups (defaults to RDAP) |
+
+The repo includes `mock_logs.json` and `domains.db` for local testing.
+
+By default domain metadata is pulled from `rdap.org`. Set `DOMAIN_INFO_API` if you
+want to use a different service.
 
 ## TODOs
 

--- a/domains.db
+++ b/domains.db
@@ -1,0 +1,11 @@
+{
+  "t.co": "Twitter",
+  "doubleclick.net": "Google",
+  "fbcdn.net": "Meta",
+  "telemetry.yourTV.com": "YourTV Corp",
+  "ads.twitter.com": "Twitter",
+  "tracking.somesite.com": "SomeSite Inc.",
+  "cdn.suspicious.com": "Suspicious Co.",
+  "analytics.example.org": "Example Analytics",
+  "weird.example": "Unknown"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,94 @@
+require('dotenv').config();
+const { Client, GatewayIntentBits, EmbedBuilder } = require('discord.js');
+const cron = require('node-cron');
+const fetch = require('node-fetch');
+const fs = require('fs');
+const { generateSummaryLLM } = require('./summarizer');
+
+// simple plugin that reads mock logs
+const { getStats } = require('./plugins/mock');
+
+const token = process.env.DISCORD_TOKEN;
+const channelId = process.env.DISCORD_CHANNEL;
+const reportTime = process.env.REPORT_TIME || '09:00';
+const domainInfoApi = process.env.DOMAIN_INFO_API || null;
+
+const domainDB = JSON.parse(fs.readFileSync('./domains.db', 'utf8'));
+
+// Fetch and aggregate DNS log stats via plugin
+async function getDailyStats() {
+  return await getStats();
+}
+
+function getDomainOwner(domain) {
+  const parts = domain.split('.');
+  const root = parts.slice(-2).join('.');
+  return domainDB[domain] || domainDB[root] || 'Unknown';
+}
+
+// Retrieve extra information about a domain
+async function getDomainInfo(domain) {
+  const url = domainInfoApi
+    ? `${domainInfoApi}${domain}`
+    : `https://rdap.org/domain/${domain}`;
+  try {
+    const res = await fetch(url);
+    return await res.json();
+  } catch (err) {
+    console.error('Domain info lookup failed:', err);
+    return null;
+  }
+}
+
+// Build a text prompt with domain data
+async function buildPrompt(stats) {
+  const infos = await Promise.all(stats.topDomains.map((d) => getDomainInfo(d)));
+
+  let lines = ['Today\'s Creepiest Domains:'];
+  stats.topDomains.forEach((domain, idx) => {
+    const owner = getDomainOwner(domain);
+    const info = infos[idx];
+    let created = '';
+    if (info) {
+      if (info.events) {
+        const reg = (info.events || []).find((e) => e.eventAction === 'registration');
+        if (reg) created = `, registered ${reg.eventDate.slice(0, 10)}`;
+      } else if (info.domains && info.domains[0]) {
+        created = `, born ${info.domains[0].create_date || 'sometime in the void'}`;
+      }
+    }
+    lines.push(`${idx + 1}. ${domain} (owned by ${owner}${created})`);
+  });
+  return lines.join('\n');
+}
+
+// Generate a humorous summary using TinyLlama
+async function generateSummary(stats) {
+  const prompt = await buildPrompt(stats);
+  const text = await generateSummaryLLM(prompt);
+  return text;
+}
+
+async function sendReport(client) {
+  const stats = await getDailyStats();
+  const summary = await generateSummary(stats);
+
+  const embed = new EmbedBuilder()
+    .setTitle('AdSnitch Daily Report')
+    .setDescription(summary)
+    .setColor(0xff9900);
+
+  const channel = await client.channels.fetch(channelId);
+  if (channel) await channel.send({ embeds: [embed] });
+}
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+client.once('ready', () => {
+  console.log('AdSnitch bot ready');
+  const [hour, minute] = reportTime.split(':');
+  cron.schedule(`${minute} ${hour} * * *`, () => sendReport(client), {
+    timezone: 'UTC'
+  });
+});
+
+client.login(token);

--- a/mock_logs.json
+++ b/mock_logs.json
@@ -1,0 +1,11 @@
+[
+  {"domain": "t.co", "count": 50},
+  {"domain": "doubleclick.net", "count": 40},
+  {"domain": "fbcdn.net", "count": 25},
+  {"domain": "telemetry.yourTV.com", "count": 20},
+  {"domain": "ads.twitter.com", "count": 15},
+  {"domain": "tracking.somesite.com", "count": 10},
+  {"domain": "cdn.suspicious.com", "count": 5},
+  {"domain": "analytics.example.org", "count": 2},
+  {"domain": "weird.example", "count": 1}
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "adsnitch",
+  "version": "1.0.0",
+  "description": "_Your TinyLlama-powered Discord tattletale that exposes the shady world of DNS requests — with sarcasm._",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.0.0",
+    "dotenv": "^16.0.0",
+    "node-cron": "^3.0.0",
+    "node-fetch": "^2.6.7",
+    "node-llama-cpp": "^3.10.0"
+  }
+}

--- a/plugins/mock.js
+++ b/plugins/mock.js
@@ -1,0 +1,11 @@
+const fs = require('fs').promises;
+
+async function getStats() {
+  const data = JSON.parse(await fs.readFile('./mock_logs.json', 'utf8'));
+  // Sort by count descending
+  const sorted = data.sort((a, b) => b.count - a.count);
+  const topDomains = sorted.map((d) => d.domain);
+  return { topDomains };
+}
+
+module.exports = { getStats };

--- a/summarizer.js
+++ b/summarizer.js
@@ -1,0 +1,31 @@
+const path = require('path');
+let llama;
+let model;
+
+async function loadModel() {
+  if (!model) {
+    const { getLlama } = require('node-llama-cpp');
+    llama = await getLlama();
+    model = await llama.loadModel({
+      modelPath: process.env.MODEL_PATH || path.join(__dirname, 'tinyllama-model.gguf')
+    });
+  }
+  return model;
+}
+
+async function generateSummaryLLM(text) {
+  try {
+    const m = await loadModel();
+    const context = await m.createContext();
+    const { LlamaChatSession } = require('node-llama-cpp');
+    const session = new LlamaChatSession({ contextSequence: context.getSequence() });
+    const prompt = `Summarize the following lines with humor:\n${text}\nHumorous summary:`;
+    const result = await session.prompt(prompt);
+    return result.trim();
+  } catch (err) {
+    console.error('TinyLlama generation failed:', err);
+    return text;
+  }
+}
+
+module.exports = { generateSummaryLLM };


### PR DESCRIPTION
## Summary
- update package to include `node-llama-cpp`
- add TinyLlama summarizer using `node-llama-cpp`
- fetch domain details from RDAP when no custom API is set
- adjust `.env.example` to note optional `DOMAIN_INFO_API`
- document new workflow and defaults in README
- mark completed tasks in project plan

## Testing
- `node -v`
- `npm --version`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ffad08d9c8330869e08b408b63817