### PR TITLE
Add OpenAI summarization option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ ADGUARD_URL=
 MODEL_PATH=./tinyllama-model
 REPORT_TIME=09:00
 DOMAIN_INFO_API=https://api.domainsdb.info/v1/domains/search?domain=
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Because... why not?
 - Fully customizable tone: sarcastic, serious, sysadmin-rage, or Munna Bhai-style
 - **Domain intelligence** lookup via RDAP for context-aware summaries
 - If no Discord token is provided, summaries are printed to the console
+- Optionally delegate summarization to OpenAI by providing `OPENAI_API_KEY` if TinyLlama is too slow on your machine
 
 ## Screenshots
 
@@ -66,6 +67,7 @@ Source code is organized under `src/` with test data in `data/`.
 | `MODEL_PATH`    | Path to TinyLlama model for local inference  |
 | `REPORT_TIME`   | Time of day to send daily summaries (HH\:MM) |
 | `DOMAIN_INFO_API` | Optional API endpoint for domain lookups (defaults to RDAP) |
+| `OPENAI_API_KEY` | Use OpenAI for summaries instead of local TinyLlama |
 
 The repo includes sample data in `data/mock_logs.json` and `data/domains.db` for local testing.
 

--- a/src/summarizer.js
+++ b/src/summarizer.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fetch = require('node-fetch');
 let llamaModule;
 let llama;
 let model;
@@ -21,7 +22,37 @@ async function loadModel() {
   return model;
 }
 
+async function generateSummaryOpenAI(text) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) return null;
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'Summarize the following lines with humor.' },
+          { role: 'user', content: text }
+        ]
+      })
+    });
+    const data = await res.json();
+    if (data.choices && data.choices[0] && data.choices[0].message) {
+      return data.choices[0].message.content.trim();
+    }
+  } catch (err) {
+    console.error('OpenAI summarization failed:', err);
+  }
+  return null;
+}
+
 async function generateSummaryLLM(text) {
+  const openai = await generateSummaryOpenAI(text);
+  if (openai) return openai;
   try {
     const llamaMod = await loadLlamaModule();
     const m = await loadModel();


### PR DESCRIPTION
## Summary
- extend summarizer to optionally use OpenAI if `OPENAI_API_KEY` is set
- document the new variable in README and `.env.example`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68600a919d3483309d35a77c8c55be74